### PR TITLE
action: update grub-arm64-efi to latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,8 +88,8 @@ runs:
         sudo pip3 install ninja
         
         # For generic-efi support
-        wget http://ports.ubuntu.com/pool/main/g/grub2-unsigned/grub-efi-arm64-bin_2.06-2ubuntu10_arm64.deb
-        sudo dpkg -x grub-efi-arm64-bin_2.06-2ubuntu10_arm64.deb /
+        wget http://ports.ubuntu.com/pool/main/g/grub2-unsigned/grub-efi-arm64-bin_2.06-2ubuntu17_arm64.deb
+        sudo dpkg -x grub-efi-arm64-bin_2.06-2ubuntu17_arm64.deb /
           
     - id: install-pacman
       shell: bash


### PR DESCRIPTION
Most of the image builds have started to fail, because the version of grub-efi for arm64 used has been removed from the ubuntu mirror pool.

So update it to the latest eg. `grub-efi-arm64-bin_2.06-2ubuntu17_arm64.deb`

Signed-off-by: Dan Johansen <strit@strits.dk>