### PR TITLE
[workflows] fix pacman builds

### DIFF
--- a/.github/workflows/aarch64_base_stable_docker_build.yaml
+++ b/.github/workflows/aarch64_base_stable_docker_build.yaml
@@ -60,7 +60,6 @@ jobs:
             sudo wget https://sources.archlinux.org/other/pacman/pacman-${PACMAN_VERSION}.tar.xz
             sudo tar -xvf pacman-${PACMAN_VERSION}.tar.xz
             pushd pacman-${PACMAN_VERSION}
-              sudo patch -p1 -i ../pacman-sync-first-option.patch
               sudo meson --prefix=/usr \
                         --buildtype=plain \
                         -Ddoc=disabled \

--- a/.github/workflows/aarch64_base_unstable_docker_build.yaml
+++ b/.github/workflows/aarch64_base_unstable_docker_build.yaml
@@ -60,7 +60,6 @@ jobs:
             sudo wget https://sources.archlinux.org/other/pacman/pacman-${PACMAN_VERSION}.tar.xz
             sudo tar -xvf pacman-${PACMAN_VERSION}.tar.xz
             pushd pacman-${PACMAN_VERSION}
-              sudo patch -p1 -i ../pacman-sync-first-option.patch
               sudo meson --prefix=/usr \
                         --buildtype=plain \
                         -Ddoc=disabled \

--- a/.github/workflows/rootfs_build.yaml
+++ b/.github/workflows/rootfs_build.yaml
@@ -56,7 +56,6 @@ jobs:
             sudo wget https://sources.archlinux.org/other/pacman/pacman-${PACMAN_VERSION}.tar.xz
             sudo tar -xvf pacman-${PACMAN_VERSION}.tar.xz
             pushd pacman-${PACMAN_VERSION}
-              sudo patch -p1 -i ../pacman-sync-first-option.patch
               sudo meson --prefix=/usr \
                         --buildtype=plain \
                         -Ddoc=disabled \


### PR DESCRIPTION
The current pacman builds contain a command to patch the source of pacman, but the patch was removed a while ago.

So fix all the workflow pacman builds by removing the patch command from them.

Signed-off-by: Dan Johansen <strit@strits.dk>