### PR TITLE
[unstable] try setting branch with pacman-mirrors command

### DIFF
--- a/.github/workflows/aarch64_base_unstable_docker_build.yaml
+++ b/.github/workflows/aarch64_base_unstable_docker_build.yaml
@@ -153,6 +153,7 @@ jobs:
           info "Setting up keyrings..."
           sudo $NSPAWN $BUILDDIR/$ARCH pacman-key --init
           sudo $NSPAWN $BUILDDIR/$ARCH pacman-key --populate archlinuxarm manjaro manjaro-arm
+          sudo $NSPAWN $BUILDDIR/$ARCH pacman-mirrors --api --set-branch arm-unstable
           sudo $NSPAWN $BUILDDIR/$ARCH pacman-mirrors -f5
           
           msg "Making Docker image..."


### PR DESCRIPTION
This is how pacman-mirrors should work and means we don't have to touch the config file.

Signed-off-by: Dan Johansen <strit@strits.dk>